### PR TITLE
Updated netdev_common.go and netstat_linux.go. Added functionality to…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 
 ARG ARCH="amd64"
 ARG OS="linux"
-COPY .build/${OS}-${ARCH}/node_exporter /bin/node_exporter
+COPY ./node_exporter /bin/node_exporter
 
 EXPOSE      9100
 USER        nobody

--- a/collector/netstat_linux.go
+++ b/collector/netstat_linux.go
@@ -36,7 +36,11 @@ const (
 )
 
 var (
-	netStatFields = kingpin.Flag("collector.netstat.fields", "Regexp of fields to return for netstat collector.").Default("^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans|TCPTimeouts)|Tcp_(ActiveOpens|InSegs|OutSegs|OutRsts|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$").String()
+	envNetstatMetrics = os.Getenv("NETSTAT_METRICS")
+	netstatMetricsList = strings.Split(envNetstatMetrics, ",")
+	regexpPattern = "^(" + strings.Join(netstatMetricsList, "|") + ")$"
+
+	netStatFields = kingpin.Flag("collector.netstat.fields", "Regexp of fields to return for netstat collector.").Default(regexpPattern).String()
 )
 
 type netStatCollector struct {


### PR DESCRIPTION
… get sub metrics names from environment variables and us it to only export the specified sub metrics